### PR TITLE
[DO NOT MERGE] Demonstrate a runtime crash when iterating an array of branches.

### DIFF
--- a/BinaryTreeTests/BinaryTreeTests.swift
+++ b/BinaryTreeTests/BinaryTreeTests.swift
@@ -36,8 +36,20 @@ final class BinaryTreeTests: XCTestCase {
 	}
 
 	func testBranchesAreBranches() {
+		for branch in branches {
+			XCTAssert(branch.isBranch)
+		}
 		XCTAssert(BinaryTree<Int>(BinaryTree(0), 0, BinaryTree(0)).isBranch)
 	}
+
+
+	// MARK: Fixtures
+
+	let branches = [
+		BinaryTree(BinaryTree(0), 0, nil),
+		BinaryTree(nil, 0, BinaryTree(0)),
+		BinaryTree<Int>(BinaryTree(0), 0, BinaryTree(0)),
+	]
 }
 
 


### PR DESCRIPTION
Demonstrates a runtime crash when iterating an array of `BinaryTree<Int>`s.
